### PR TITLE
对齐第 682 行 * 2

### DIFF
--- a/super-tiny-compiler-chinese.js
+++ b/super-tiny-compiler-chinese.js
@@ -679,7 +679,7 @@ function traverser(ast, visitor) {
  *                                    |             type: 'NumberLiteral',
  *                                    |             value: '2'
  *                                    |           }]
- *         (那一边比较长/w\)           |         }]
+ *         (那一边比较长/w\)            |         }]
  *                                    |       }
  *                                    |     }]
  *                                    |   }


### PR DESCRIPTION
不知道是不是字体原因，我在本地用等宽字体看第 682 行是歪的，但是 #3 之前是正的……
嗯他用的可能不是等宽字体
btw 浏览器上还是歪的aaaaa